### PR TITLE
Clarify how comments work

### DIFF
--- a/docs/SyntaxForModels.md
+++ b/docs/SyntaxForModels.md
@@ -7,7 +7,7 @@ title: Syntax for Models
 
 - If a model uses RBAC, it should also add the ``[role_definition]`` section.
 
-- A model CONF can contain comments. The comments start with ``#``, and ``#`` will comment the whole line.
+- A model CONF can contain comments. The comments start with ``#``, and ``#`` will comment the rest of the line.
 
 ## Request definition
 


### PR DESCRIPTION
It's a minor clarification, I know, but when I read this part of the documentation, I thought to myself "That's a weird way for comments to work"... but when I tested it, comments work exactly as you would expect, just the description seems a little weird.

The existing description implies that a `#` anywhere on a line will comment that entire line.  This change clarifies that a `#` will only comment the rest of the line following the `#`