### PR TITLE
Adding end tag for avoiding other tab collapse.

### DIFF
--- a/docs/ManagementAPI.md
+++ b/docs/ManagementAPI.md
@@ -896,6 +896,8 @@ rules := [][] string {
 areRulesAdded := e.AddNamedGroupingPolicies("g", rules)
 ```
 
+<!--END_DOCUSAURUS_CODE_TABS-->
+
 ### `RemoveGroupingPolicy()`
 
 RemoveGroupingPolicy removes a role inheritance rule from the current policy.
@@ -943,6 +945,8 @@ rules := [][] string {
 
 areRulesRemoved := e.RemoveGroupingPolicies(rules)
 ```
+
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 ### `RemoveFilteredGroupingPolicy()`
 

--- a/docs/ManagementAPI.md
+++ b/docs/ManagementAPI.md
@@ -1017,6 +1017,8 @@ rules := [][] string {
 areRulesRemoved := e.RemoveNamedGroupingPolicies("g", rules)
 ```
 
+<!--END_DOCUSAURUS_CODE_TABS-->
+
 ### `RemoveFilteredNamedGroupingPolicy()`
 
 RemoveFilteredNamedGroupingPolicy removes a role inheritance rule from the current named policy, field filters can be specified.


### PR DESCRIPTION
![Screenshot (100)_LI](https://user-images.githubusercontent.com/39230975/77511287-ca83b380-6e96-11ea-9342-f4359a0e204d.jpg)

It is because I forgot to add the end-tag. Sorry, it won't happen again.