### PR TITLE
Add new PostgreSQL adapter for node-casbin

### DIFF
--- a/docs/Adapters.md
+++ b/docs/Adapters.md
@@ -61,6 +61,7 @@ Adapter | Type | Author | AutoSave | Description
 [Mongoose Adapter](https://github.com/node-casbin/mongoose-adapter) | ORM | [elastic.io](https://github.com/elasticio) and Casbin | ✅ | MongoDB is supported by [Mongoose](https://mongoosejs.com/)
 [Knex Adapter](https://github.com/sarneeh/casbin-knex-adapter) | ORM | [@sarneeh](https://github.com/sarneeh) | ✅ | MSSQL, MySQL, PostgreSQL, SQLite3, Oracle are supported by [Knex.js](https://knexjs.org/)
 [Node MongoDB Native Adapter](https://github.com/juicycleff/casbin-mongodb-adapter) | NoSQL | [@juicycleff](https://github.com/juicycleff) | ✅ | For [Node MongoDB Native](https://mongodb.github.io/node-mongodb-native/)
+[Node PostgreSQL Native Adapter](https://github.com/touchifyapp/casbin-pg-adapter) | SQL | [@touchifyapp](https://github.com/touchifyapp) | ✅ | PostgreSQL adapter with advanced policy subset loading support and improved performances built with [node-postgres](https://node-postgres.com/).
 [Couchbase Adapter](https://github.com/sarneeh/casbin-knex-adapter) | NoSQL | [@MarkMYoung](https://github.com/MarkMYoung) | ✅ | For [Couchbase](https://www.couchbase.com/)
 [Redis Adapter](https://github.com/NandaKishorJeripothula/node-casbin-redis-adapter) | KV store | [@NandaKishorJeripothula](https://github.com/NandaKishorJeripothula) | ❌ | For [Redis](https://redis.io/)
 


### PR DESCRIPTION
At Touchify, we use Casbin for access control over our API.
We allows users to manage their own access control on their projects so we manage a very big policies database.

With this in mind, we built a "native" PostgreSQL adapter for Casbin with improved performances and advanced policy filtering.

Here are the advanced filters:
```typescript
// Load the filtered policy from DB.
await e.loadFilteredPolicy({
    p: ["regex:(role:.*)|(alice)"],
    g: ["", "like:role:%"]
});
```

**Details:**
* `like:` prefix: generates a `WHERE` clause using `LIKE` operator on PostgreSQL
* `regex:` prefix: generates a `WHERE` clause using `~` (regex) operator on PostgreSQL

It allows us to only query the necessaries policies to evaluate the right to increase the evaluation performances.

We hope that this adapter will helps others so we decided to release it in open-source to help your community.

Thanks for this wonderful project!