### PR TITLE
Add the css to make the heading at centre

### DIFF
--- a/website/static/css/docusaurus-admonitions.css
+++ b/website/static/css/docusaurus-admonitions.css
@@ -100,3 +100,6 @@
   stroke: #f1c40f;
   fill: #f1c40f;
 }
+.container .wrapper .imageAlignSide h2 {
+  text-align: center;
+}


### PR DESCRIPTION
In Reference to #87 

On going through the code. The previous rule of css left aligned the heading so, I overide the rule may be it helpful. 