### PR TITLE
fix: Show hidden back-to-top button.

### DIFF
--- a/website/static/css/code-blocks-buttons.css
+++ b/website/static/css/code-blocks-buttons.css
@@ -37,3 +37,8 @@ pre .btnIcon:hover {
 .btnClipboard {
   right: 10px;
 }
+
+#back-to-top{
+  bottom: 50px;
+  right: 50px;
+}


### PR DESCRIPTION
fix: #85 
![Screenshot (123)](https://user-images.githubusercontent.com/39230975/82070648-abfda400-96f2-11ea-839d-98c4240a6bc9.png)
