### PR TITLE
Fix typo in Overview.md

### DIFF
--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -43,7 +43,7 @@ What Casbin does:
 1. enforce the policy in the classic ``{subject, object, action}`` form or a customized form as you defined, both allow and deny authorizations are supported.
 2. handle the storage of the access control model and its policy.
 3. manage the role-user mappings and role-role mappings (aka role hierarchy in RBAC).
-4. support built-in superuser like ``root`` or ``administrator``. A superuser can do anything without explict permissions.
+4. support built-in superuser like ``root`` or ``administrator``. A superuser can do anything without explicit permissions.
 5. multiple built-in operators to support the rule matching. For example, ``keyMatch`` can map a resource key ``/foo/bar`` to the pattern ``/foo*``.
 
 What Casbin does NOT do:


### PR DESCRIPTION
Minor change typo (explicit instead of explict) in What Casbin does: line four (4).