### PR TITLE
fix: Brand name looks changed

### DIFF
--- a/website/static/css/docusaurus-admonitions.css
+++ b/website/static/css/docusaurus-admonitions.css
@@ -112,3 +112,7 @@
   display:inline-block;
   width:100px
 }
+header>a:hover{
+  color:#fff;
+  text-decoration: none;
+}


### PR DESCRIPTION
Fix: https://github.com/casbin/casbin-website/issues/227

changed the brand name hover features as follow:
1. Removed the underline text decoration
2. On hover, the color won't change, instead only the cursor changes to pointer