### PR TITLE
docs: Add Tortoise ORM adapter

### DIFF
--- a/docs/Adapters.md
+++ b/docs/Adapters.md
@@ -108,6 +108,7 @@ Adapter | Type | Author | AutoSave | Description
 [Couchbase Adapter](https://github.com/ScienceLogic/casbin-couchbase-adapter) | NoSQL | [ScienceLogic](https://github.com/ScienceLogic) | ✅ (without `remove_filtered_policy()`) | For [Couchbase](https://www.couchbase.com/)
 [DynamoDB Adapter](https://github.com/abqadeer/python-dycasbin) | NoSQL | [@abqadeer](https://github.com/abqadeer/) | ✅ | For [DynamoDB](https://aws.amazon.com/dynamodb/)
 [Pymongo Adapter](https://github.com/pycasbin/pymongo-adapter) | NoSQL |  Casbin | ❌ | MongoDB is supported by [Pymongo](https://pypi.org/project/pymongo/)
+[Tortoise ORM Adapter](https://github.com/thearchitector/casbin-tortoise-adapter) | ORM |  [@thearchitector](https://github.com/thearchitector) | ✅ | PostgreSQL (>=9.4), MySQL, MariaDB, and SQLite are supported by [Tortoise ORM](https://tortoise.github.io/databases.html)
 
 <!--.NET-->
 Adapter | Type | Author | AutoSave | Description

--- a/docs/Adapters.md
+++ b/docs/Adapters.md
@@ -105,10 +105,10 @@ Adapter | Type | Author | AutoSave | Description
 [Peewee Adapter](https://github.com/shblhy/peewee-adapter) | ORM | [@shblhy](https://github.com/shblhy) | ✅ | PostgreSQL, MySQL, SQLite are supported by [Peewee](http://docs.peewee-orm.com/)
 [MongoEngine Adapter](https://github.com/zhangbailong945/mongoengine_adapter) | ORM | [@zhangbailong945](https://github.com/zhangbailong945) | ❌ | MongoDB is supported by [MongoEngine](http://mongoengine.org/)
 [Pony ORM Adapter](https://github.com/drorvinkler/pycasbin-pony-adapter) | ORM | [@drorvinkler](https://github.com/drorvinkler) | ✅ | MySQL, PostgreSQL, SQLite, Oracle, CockroachDB are supported by [Pony ORM](https://ponyorm.org/)
+[Tortoise ORM Adapter](https://github.com/thearchitector/casbin-tortoise-adapter) | ORM |  [@thearchitector](https://github.com/thearchitector) | ✅ | PostgreSQL (>=9.4), MySQL, MariaDB, and SQLite are supported by [Tortoise ORM](https://tortoise.github.io/databases.html)
 [Couchbase Adapter](https://github.com/ScienceLogic/casbin-couchbase-adapter) | NoSQL | [ScienceLogic](https://github.com/ScienceLogic) | ✅ (without `remove_filtered_policy()`) | For [Couchbase](https://www.couchbase.com/)
 [DynamoDB Adapter](https://github.com/abqadeer/python-dycasbin) | NoSQL | [@abqadeer](https://github.com/abqadeer/) | ✅ | For [DynamoDB](https://aws.amazon.com/dynamodb/)
 [Pymongo Adapter](https://github.com/pycasbin/pymongo-adapter) | NoSQL |  Casbin | ❌ | MongoDB is supported by [Pymongo](https://pypi.org/project/pymongo/)
-[Tortoise ORM Adapter](https://github.com/thearchitector/casbin-tortoise-adapter) | ORM |  [@thearchitector](https://github.com/thearchitector) | ✅ | PostgreSQL (>=9.4), MySQL, MariaDB, and SQLite are supported by [Tortoise ORM](https://tortoise.github.io/databases.html)
 
 <!--.NET-->
 Adapter | Type | Author | AutoSave | Description


### PR DESCRIPTION
Adds [casbin-tortoise-adapter](https://github.com/thearchitector/casbin-tortoise-adapter) for AsyncCasbin to the list of 3rd party adapters.