### PR TITLE
fix: Lua Casbin docs and formatting and added Lua Casbin adapters

### DIFF
--- a/docs/Adapters.md
+++ b/docs/Adapters.md
@@ -140,6 +140,14 @@ Adapter | Type | Author | AutoSave | Description
 [Memory Adapter (built-in)](https://github.com/casbin/SwiftCasbin/blob/master/Sources/Casbin/Adapter/MemoryAdapter.swift) | Memory | Casbin | ❌ | For memory
 [Fluent Adapter](https://github.com/SwiftCasbin/fluent-adapter) | ORM | Casbin | ✅ | [PostgreSQL, SQLite, MySQL, MongoDB](https://docs.vapor.codes/4.0/fluent/overview/#drivers) are supported by [Fluent](https://github.com/vapor/fluent)
 
+<!--Lua-->
+Adapter | Type | Author | AutoSave | Description
+----|------|----|----|----
+[File Adapter (built-in)](https://casbin.org/docs/en/adapters#file-adapter-built-in) | File | Casbin | ❌ | For [.CSV (Comma-Separated Values)](https://en.wikipedia.org/wiki/Comma-separated_values) files
+[Filtered File Adapter (built-in)](https://casbin.org/docs/en/policy-subset-loading) | File | Casbin | ❌ | For [.CSV (Comma-Separated Values)](https://en.wikipedia.org/wiki/Comma-separated_values) files with policy subset loading support
+[LuaSQL Adapter](https://github.com/casbin-lua/luasql-adapter) | ORM | Casbin | ✅ | MySQL, PostgreSQL, SQLite3 are supported by [LuaSQL](https://keplerproject.github.io/luasql/)
+[4DaysORM Adapter](https://github.com/casbin-lua/4daysorm-adapter) | ORM | Casbin | ✅ | MySQL, SQLite3 are supported by [4DaysORM](https://github.com/itdxer/4DaysORM)
+
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 :::note

--- a/docs/GetStarted.md
+++ b/docs/GetStarted.md
@@ -174,9 +174,8 @@ async fn main() -> Result<()> {
 <!--Lua-->
 
 ```lua
-lua_package_path "$prefix/lua/?.lua;$prefix/lua-casbin/?.lua;;";
-local Enforcer = require("src.main.Enforcer")
-local e = Enforcer:new("path/to/model.conf","path/to/policy.cvs") -- The Casbin Enforcer
+local Enforcer = require("casbin")
+local e = Enforcer:new("path/to/model.conf", "path/to/policy.csv") -- The Casbin Enforcer
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->
@@ -348,11 +347,10 @@ else
 <!--Lua-->
 
 ```lua
-if e:enforce("alice", "data1", "read")
-then
-   --permit alice to read data1
+if e:enforce("alice", "data1", "read") then
+   -- permit alice to read data1
 else
-   --error occurs
+   -- deny the request, show an error
 end
 
 ```
@@ -407,7 +405,7 @@ let roles = e.get_roles_for_user("alice");
 <!--Lua-->
 
 ```lua
-local roles =e:GetRolesForUser("alice")
+local roles = e:GetRolesForUser("alice")
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->


### PR DESCRIPTION
Since we already have `casbin` module in path from LuaRocks, we don't need to add it separately in `package.path`. Also, this makes the formatting a bit more consistent.