### PR TITLE
feat: Add roleManager python examples for get methods

### DIFF
--- a/docs/RoleManagerApi.md
+++ b/docs/RoleManagerApi.md
@@ -90,6 +90,11 @@ For example:
     const rm = await e.getRoleManager();
 ```
 
+<!--Python-->
+```python
+    rm = e.get_role_manager()
+```
+
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 ### `Clear()`
@@ -195,6 +200,11 @@ For example:
     await rm.getRoles('u1', 'domain1');
 ```
 
+<!--Python-->
+```python
+    rm.get_roles("u1", "domain")
+```
+
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 ### `GetUsers()`
@@ -214,6 +224,11 @@ For example:
 <!--Node.js-->
 ```typescript
     await rm.getUsers('g1');
+```
+
+<!--Python-->
+```python
+    rm.get_users("g1")
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->


### PR DESCRIPTION
This PR adds  python code snippet on RoleManager API docs page for following methods:

- getRoleManager
- getUsers
- getRoles