### PR TITLE
fix: typo in Overview.md

### DIFF
--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -19,7 +19,7 @@ production-ready | production-ready | production-ready | production-ready
 
 ## Feature set for different languages
 
-Feature | Go | Java | Node.js | PHP | Python | C# | Delphi | Rust | C++ | Lua |Dart | Exilir
+Feature | Go | Java | Node.js | PHP | Python | C# | Delphi | Rust | C++ | Lua |Dart | Elixir
 ----|----|----|----|----|----|----|----|----|---- | ---- | ---- | ---- 
 Enforcement | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅|✅|✅|✅
 RBAC | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅|✅|✅|✅


### PR DESCRIPTION
Minor change typo (Elixir instead of Exilir) in Overview.md

Signed-off-by: BSS ZU <274620705z@gmail.com>